### PR TITLE
anchor-pom#6 solve security alerts in github by upgrading junit versi…

### DIFF
--- a/anchor-core/pom.xml
+++ b/anchor-core/pom.xml
@@ -42,7 +42,7 @@
 	<dependency>
 	  <groupId>com.thoughtworks.xstream</groupId>
 	  <artifactId>xstream</artifactId>
-	  <version>1.4.11.1</version>
+	  <version>1.4.14-jdk7</version>
 	</dependency>    
   </dependencies>
 </project>


### PR DESCRIPTION
…on to 4.13.1 and xstream version to 1.4.14-jdk7